### PR TITLE
[FIX] Add default background color to cards

### DIFF
--- a/src/styling/atoms/Card.jsx
+++ b/src/styling/atoms/Card.jsx
@@ -8,4 +8,5 @@ export const Card = styled.div`
     `${props.paddingY ? props.paddingY : '36px'} ${props.paddingX ? props.paddingX : '24px'}`};
   border-radius: ${props => (props.radius ? props.radius : '4px')};
   ${props => (props.shadow ? `box-shadow: ${props.shadow};` : null)};
+  background: ${props => (props.background ? props.background : 'white')};
 `;


### PR DESCRIPTION
# Description

Some of the cards have transparent backgrounds as the backgrounds aren't set on the root card component. This will fix that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe steps taken to ensure this feature is functional and does not break other features:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if relevant
- [x] I have run the app using my feature and ensured that no functionality is broken
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
